### PR TITLE
Add fishing game documentation

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -35,6 +35,7 @@ export default defineConfig({
                         {label: 'Sounds', slug: 'bahms/sounds'},
                         {label: 'TTS', slug: 'bahms/tts'},
                         {label: 'Duels', slug: 'bahms/duels'},
+                        {label: 'Fishing', slug: 'bahms/fishing'},
                         {label: 'Slot Machine', slug: 'bahms/slot-machine'},
                         {label: 'Bounce House', slug: 'bahms/bounce-house'},
                         {label: 'Juniper', slug: 'bahms/juniper'},

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -45,6 +45,12 @@ export default defineConfig({
                 {label: 'Commands', slug: 'commands'},
                 {label: 'Redeems', slug: 'redeems'},
                 {label: 'Usercard', slug: 'usercard'},
+                {
+                    label: 'API documentation',
+                    link: 'https://api.bahms.org',
+                    // Open in a separate tab / window.
+                    attrs: { target: '_blank' }
+                },
             ],
         }),
     ],

--- a/src/content/components/FishSpeciesOverview.astro
+++ b/src/content/components/FishSpeciesOverview.astro
@@ -1,9 +1,18 @@
 <fish-species-table />
 
 <script>
+    const rarityLevels = ['COMMON', 'UNCOMMON', 'RARE', 'EPIC', 'LEGENDARY'];
+    const getRarityLevel = (rarity) => {
+        return rarityLevels.findIndex((candidate) => candidate === rarity) ?? 0;
+    }
+
     // Fetch the fish species during runtime, not during build time.
     const response = await fetch('https://api.bahms.org/v1/fishing/fish');
-    const fishSpecies = await response.json();
+    const fishSpecies = (await response.json()).sort((a, b) =>
+        a.rarity === b.rarity
+            ? a.name.localeCompare(b.name)
+            : getRarityLevel(a.rarity) - getRarityLevel(b.rarity)
+    );
 
     if (typeof fishSpecies !== 'object') {
         console.error('Could not load fish species from API endpoint');
@@ -14,7 +23,6 @@
         FRESHWATER: 'fresh water',
     }
 
-    const rarityLevels = ['COMMON', 'UNCOMMON', 'RARE', 'EPIC', 'LEGENDARY'];
     const createRarityMeter = (rarity) => {
         const meter = document.createElement('meter');
         meter.title = rarity.toLowerCase();
@@ -23,7 +31,7 @@
         meter.low = 1;
         meter.high = rarityLevels.length - 2;
         meter.optimum = Math.ceil((rarityLevels.length - 1) / 2);
-        meter.value = rarityLevels.findIndex((candidate) => candidate === rarity) ?? 0;
+        meter.value = getRarityLevel(rarity);
         return meter;
     }
 

--- a/src/content/components/FishSpeciesOverview.astro
+++ b/src/content/components/FishSpeciesOverview.astro
@@ -2,9 +2,9 @@
 
 <script>
     const rarityLevels = ['COMMON', 'UNCOMMON', 'RARE', 'EPIC', 'LEGENDARY'];
-    const getRarityLevel = (rarity) => {
-        return rarityLevels.findIndex((candidate) => candidate === rarity) ?? 0;
-    }
+    const getRarityLevel = (rarity) => rarityLevels.findIndex(
+        (candidate) => candidate === rarity
+    ) ?? 0;
 
     // Fetch the fish species during runtime, not during build time.
     const response = await fetch('https://api.bahms.org/v1/fishing/fish');

--- a/src/content/components/FishSpeciesOverview.astro
+++ b/src/content/components/FishSpeciesOverview.astro
@@ -104,6 +104,7 @@
     fish-species-table {
         display: block;
         margin-block-start: 1em;
+        margin-block-end: 2em;
 
         meter {
             --background: color(from var(--sl-color-bg-accent) srgb r g b / 0.1);

--- a/src/content/components/FishSpeciesOverview.astro
+++ b/src/content/components/FishSpeciesOverview.astro
@@ -1,0 +1,152 @@
+<fish-species-table />
+
+<script>
+    // Fetch the fish species during runtime, not during build time.
+    const response = await fetch('https://api.bahms.org/v1/fishing/fish');
+    const fishSpecies = await response.json();
+
+    if (typeof fishSpecies !== 'object') {
+        console.error('Could not load fish species from API endpoint');
+    }
+
+    const environments = {
+        SALTWATER: 'salt water',
+        FRESHWATER: 'fresh water',
+    }
+
+    const rarityLevels = ['COMMON', 'UNCOMMON', 'RARE', 'EPIC', 'LEGENDARY'];
+    const createRarityMeter = (rarity) => {
+        const meter = document.createElement('meter');
+        meter.title = rarity.toLowerCase();
+        meter.min = 0;
+        meter.max = rarityLevels.length - 1;
+        meter.low = 1;
+        meter.high = rarityLevels.length - 2;
+        meter.optimum = Math.ceil((rarityLevels.length - 1) / 2);
+        meter.value = rarityLevels.findIndex((candidate) => candidate === rarity) ?? 0;
+        return meter;
+    }
+
+    class FishSpeciesList extends HTMLElement {
+        connectedCallback() {
+            const table = document.createElement('table');
+            const thead = document.createElement('thead');
+            const tbody = document.createElement('tbody');
+
+            thead.innerHTML = '<tr><th colspan="2">Fish</th><th>Rarity</th><th>Environment</th></tr>';
+
+            for (const { id, name, rarity, environment, 'img-base64': imgData } of fishSpecies) {
+                const record = document.createElement('tr');
+                record.id = `fish-${id}`;
+
+                // Create new HTML nodes for the current fish species.
+                const iconCell = document.createElement('td');
+                const fishCell = document.createElement('td');
+                const rarityCell = document.createElement('td');
+                const environmentCell = document.createElement('td');
+                const anchor = document.createElement('a');
+
+                // Add an icon image.
+                const image = document.createElement('img');
+                image.src = `data:;base64,${imgData}`;
+                image.alt = name;
+                iconCell.append(image);
+
+                // Create an anchor that links to the current badge definition.
+                anchor.href = `#${record.id}`;
+                anchor.innerText = name;
+                fishCell.title = name;
+
+                // Set the basic structure.
+                fishCell.append(anchor);
+                environmentCell.innerText = (environments[environment] ?? environment).toLowerCase();
+
+                rarityCell.innerText = rarity.toLowerCase();
+                rarityCell.prepend(createRarityMeter(rarity));
+
+                record.append(iconCell);
+                record.append(fishCell);
+                record.append(rarityCell);
+                record.append(environmentCell);
+                tbody.append(record);
+            }
+
+            // Reset the list.
+            this.innerHTML = '';
+
+            if (fishSpecies.length > 0) {
+                table.append(thead);
+                table.append(tbody);
+                this.append(table);
+            }
+        }
+    }
+
+    if (typeof fishSpecies === 'object') {
+        customElements.define('fish-species-table', FishSpeciesList);
+    }
+</script>
+
+<style>
+    fish-species-table {
+        display: block;
+        margin-block-start: 1em;
+
+        meter {
+            --background: color(from var(--sl-color-bg-accent) srgb r g b / 0.1);
+            --optimum: var(--sl-color-accent-high);
+            --sub-optimum: var(--sl-color-accent);
+            --sub-sub-optimum: var(--sl-color-accent-low);
+            --height: 16px;
+            --width: 84px;
+            --background-size: 17px 16px;
+
+            position: relative;
+            height: var(--height);
+            width: var(--width);
+
+            display: inline-block;
+            margin-inline-end: 1em;
+
+            /* The gray background in Firefox */
+            background: var(--background);
+        }
+
+        /* The gray background in Chrome, etc. */
+        meter::-webkit-meter-bar {
+            background: var(--background);
+            height: var(--height);
+        }
+
+        /* The green (optimum) bar in Firefox */
+        meter:-moz-meter-optimum::-moz-meter-bar {
+            background: var(--optimum);
+            height: var(--height);
+        }
+
+        /* The green (optimum) bar in Chrome etc. */
+        meter::-webkit-meter-optimum-value {
+            background: var(--optimum);
+        }
+
+        /* The yellow (sub-optimum) bar in Firefox */
+        meter:-moz-meter-sub-optimum::-moz-meter-bar {
+            background: var(--sub-optimum);
+        }
+
+        /* The yellow (sub-optimum) bar in Chrome etc. */
+        meter::-webkit-meter-suboptimum-value {
+            background: var(--sub-optimum);
+        }
+
+        /* The red (even less good) bar in Firefox */
+        meter:-moz-meter-sub-sub-optimum::-moz-meter-bar {
+            background: var(--sub-sub-optimum);
+        }
+
+        /* The red (even less good) bar in Chrome etc. */
+        meter::-webkit-meter-even-less-good-value {
+            background: var(--sub-sub-optimum);
+        }
+    }
+</style>

--- a/src/content/components/FishSpeciesOverview.astro
+++ b/src/content/components/FishSpeciesOverview.astro
@@ -1,4 +1,15 @@
-<fish-species-table />
+<fish-species-table>
+    <table>
+        <thead>
+            <tr>
+                <th colspan="2">Fish</th>
+                <th>Rarity</th>
+                <th>Environment</th>
+            </tr>
+        </thead>
+        <tbody />
+    </table>
+</fish-species-table>
 
 <script>
     const rarityLevels = ['COMMON', 'UNCOMMON', 'RARE', 'EPIC', 'LEGENDARY'];
@@ -37,11 +48,14 @@
 
     class FishSpeciesList extends HTMLElement {
         connectedCallback() {
-            const table = document.createElement('table');
-            const thead = document.createElement('thead');
-            const tbody = document.createElement('tbody');
+            const tbody = this.querySelector('table tbody');
 
-            thead.innerHTML = '<tr><th colspan="2">Fish</th><th>Rarity</th><th>Environment</th></tr>';
+            if (!tbody) {
+                throw new Error('Could not render Fish Species List without table body');
+            }
+
+            // Reset the table.
+            tbody.innerHTML = '';
 
             for (const { id, name, rarity, environment, 'img-base64': imgData } of fishSpecies) {
                 const record = document.createElement('tr');
@@ -77,15 +91,6 @@
                 record.append(rarityCell);
                 record.append(environmentCell);
                 tbody.append(record);
-            }
-
-            // Reset the list.
-            this.innerHTML = '';
-
-            if (fishSpecies.length > 0) {
-                table.append(thead);
-                table.append(tbody);
-                this.append(table);
             }
         }
     }

--- a/src/content/docs/bahms/fishing.mdx
+++ b/src/content/docs/bahms/fishing.mdx
@@ -26,6 +26,25 @@ In order to play the fishing game, the player needs a rod.
     3. See what fish you caught [in the stream](https://www.twitch.tv/just__jane/).
 </Steps>
 
+## Battle Phases
+
+To catch a fish, you must win against the fish across three challenges.
+Just like in real fishing.
+
+These steps will play out in real time before your very eyes:
+
+<Steps>
+    1. **Lure:** First and foremost, the lure must be alluring to the fish.
+       Fish have varied taste and some fish are more cunning than others.
+    2. **Hook:** An interested fish will take a bite, but it might escape the
+       hook if it succeeds its saving though.
+    3. **Line:** This is where the real battle begins.
+       A test of strength and stamina occurs until either the fish gets away, or
+       you reel it in.
+</Steps>
+
+Complete all three steps and you got yourself a new fish!
+
 ## Species
 
 <Aside type="note">

--- a/src/content/docs/bahms/fishing.mdx
+++ b/src/content/docs/bahms/fishing.mdx
@@ -1,0 +1,5 @@
+---
+title: Fishing game
+description: Introduction to fishing
+---
+

--- a/src/content/docs/bahms/fishing.mdx
+++ b/src/content/docs/bahms/fishing.mdx
@@ -2,5 +2,50 @@
 title: Fishing game
 description: Introduction to fishing
 ---
+import {Aside, LinkButton, Steps} from "@astrojs/starlight/components";
+
+a cat girl needs her fish snack - nya
+
+<Aside type="caution">
+    The fishing game is in active development and the mechanics may change on a
+    daily basis.
+    Use this documentation with caution, as it may very well be out-of-date.
+</Aside>
 
 ## Prerequisites
+
+In order to play the fishing game, the player needs a rod.
+
+<LinkButton href="/redeems/#test-rod-lvl-1" icon="right-arrow" iconPlacement="start">Test Rod LVL 1</LinkButton>
+
+## How to play
+
+<Steps>
+    1. Meet all [prerequisites](#prerequisites)
+    2. Use the [`!fish` command](/commands/#fishing)
+    3. See what fish you caught [on stream](https://www.twitch.tv/just__jane/).
+</Steps>
+
+## Species
+
+<Aside type="note">
+    **WIP**: This will show a list of all fish species that can be caught.
+</Aside>
+
+## Rods
+
+<Aside type="note">
+    **WIP**: This will show a list of all fishing rods that can be acquired.
+</Aside>
+
+## Lures
+
+<Aside type="note">
+    **WIP**: This will show a list of all fishing lures that can be acquired.
+</Aside>
+
+## Bait
+
+<Aside type="note">
+    **WIP**: This will show a list of all fishing bait that can be acquired.
+</Aside>

--- a/src/content/docs/bahms/fishing.mdx
+++ b/src/content/docs/bahms/fishing.mdx
@@ -3,6 +3,7 @@ title: Fishing game
 description: Introduction to fishing
 ---
 import {Aside, LinkButton, Steps} from "@astrojs/starlight/components";
+import FishSpeciesOverview from "../../components/FishSpeciesOverview.astro";
 
 a cat girl needs her fish snack - nya
 
@@ -47,9 +48,9 @@ Complete all three steps and you got yourself a new fish!
 
 ## Species
 
-<Aside type="note">
-    **WIP**: This will show a list of all fish species that can be caught.
-</Aside>
+The following fish can be caught.
+
+<FishSpeciesOverview />
 
 ## Rods
 

--- a/src/content/docs/bahms/fishing.mdx
+++ b/src/content/docs/bahms/fishing.mdx
@@ -52,6 +52,13 @@ The following fish species can be caught.
 
 <FishSpeciesOverview />
 
+<Aside type="note">
+    The fish art seen on stream and in this documentation is temporary and used
+    as a placeholder.
+
+    Temporary fish art by https://pixerelia.itch.io/lets-go-fishing
+</Aside>
+
 ## Rods
 
 <Aside type="note">

--- a/src/content/docs/bahms/fishing.mdx
+++ b/src/content/docs/bahms/fishing.mdx
@@ -3,3 +3,4 @@ title: Fishing game
 description: Introduction to fishing
 ---
 
+## Prerequisites

--- a/src/content/docs/bahms/fishing.mdx
+++ b/src/content/docs/bahms/fishing.mdx
@@ -23,7 +23,7 @@ In order to play the fishing game, the player needs a rod.
 <Steps>
     1. Meet all [prerequisites](#prerequisites)
     2. Use the [`!fish` command](/commands/#fishing)
-    3. See what fish you caught [on stream](https://www.twitch.tv/just__jane/).
+    3. See what fish you caught [in the stream](https://www.twitch.tv/just__jane/).
 </Steps>
 
 ## Species

--- a/src/content/docs/bahms/fishing.mdx
+++ b/src/content/docs/bahms/fishing.mdx
@@ -48,7 +48,7 @@ Complete all three steps and you got yourself a new fish!
 
 ## Species
 
-The following fish can be caught.
+The following fish species can be caught.
 
 <FishSpeciesOverview />
 

--- a/src/content/docs/commands.mdx
+++ b/src/content/docs/commands.mdx
@@ -2,6 +2,7 @@
 title: Commands
 description: Introduction to commands
 ---
+import {Aside} from "@astrojs/starlight/components";
 import MarketPrice from "../components/MarketPrice.astro"
 
 commands are prefixed with either `!` or `bang `.
@@ -98,6 +99,19 @@ chat has fun in the [bounce house](/bahms/bounce-house/) while I ignore them
 | `!whatever <msg>`    |            1            | adds your message to the bounce house         |
 | `!my-color`          |            0            | gets your configured color                    |
 | `!set-color <#hex6>` |            0            | attempts to set your unique user color        |
+
+## fishing
+
+To play in the [fishing game](/bahms/fishing), make sure you meet all its
+[prerequisites](/bahms/fishing/#prerequisites).
+
+| command | description                    |
+|:--------|:-------------------------------|
+| `!fish` | test your luck and cast a line |
+
+<Aside type="tip">
+    Be sure to have a [rod redeemed](/redeems/#test-rod-lvl-1).
+</Aside>
 
 ## friends
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -26,4 +26,5 @@ import {CardGrid, LinkCard} from '@astrojs/starlight/components';
     <LinkCard title="Commands" href="/commands" icon="document" description="Try out various commands."/>
     <LinkCard title="Redeems" href="/redeems" icon="document" description="Interact with various redeems."/>
     <LinkCard title="Usercard" href="/usercard" icon="document" description="User information."/>
+    <LinkCard title="API documentation" href="https://api.bahms.org" description="Integrate with B.A.H.M.S." />
 </CardGrid>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -22,6 +22,7 @@ import {CardGrid, LinkCard} from '@astrojs/starlight/components';
     <LinkCard title="Bounce House" href="/bahms/bounce-house" icon="document" description="Chaos-filled stream overlay with chatters, emoji, ships and messages."/>
     <LinkCard title="TTS" href="/bahms/tts" icon="document" description="Speak your mind out loud."/>
     <LinkCard title="Duels" href="/bahms/duels" destructive icon="document" description="Bang other chatters in a contest of speed and delay."/>
+    <LinkCard title="Fishing" href="/bahms/fishing" destructive icon="document" description="We cast a line, and we fish."/>
     <LinkCard title="Commands" href="/commands" icon="document" description="Try out various commands."/>
     <LinkCard title="Redeems" href="/redeems" icon="document" description="Interact with various redeems."/>
     <LinkCard title="Usercard" href="/usercard" icon="document" description="User information."/>

--- a/src/content/docs/introduction.mdx
+++ b/src/content/docs/introduction.mdx
@@ -36,6 +36,7 @@ Bespoke Artisanal Hand-crafted Meme Software.
     <LinkCard title="Sounds" href="/bahms/sounds" description="Sounds that can be played by typing certain words or phrases in chat." />
     <LinkCard title="TTS" href="/bahms/tts" description="Speak your mind out loud." />
     <LinkCard title="Duels" href="/bahms/duels" description="Bang other chatters in a contest of speed and delay." />
+    <LinkCard title="Fishing" href="/bahms/fishing" description="We cast a line, and we fish." />
     <LinkCard title="Credits" href="/bahms/credits" description="Every stream must end, and so do Jane streams." />
     <LinkCard title="Giga VIP" href="/giga-vip" description="The bespoke currency underpinning most B.A.H.M.S." />
 </CardGrid>

--- a/src/content/docs/introduction.mdx
+++ b/src/content/docs/introduction.mdx
@@ -41,6 +41,12 @@ Bespoke Artisanal Hand-crafted Meme Software.
     <LinkCard title="Giga VIP" href="/giga-vip" description="The bespoke currency underpinning most B.A.H.M.S." />
 </CardGrid>
 
+### API
+
+Hey guess what. That's right! We even have an API.
+
+<LinkButton icon="rocket" iconPlacement="start" href="https://api.bahms.org">B.A.H.M.S. API documentation</LinkButton>
+
 ## Rules
 
 To keep the stream fun and engaging for everyone, please follow these rules.

--- a/src/content/docs/redeems.mdx
+++ b/src/content/docs/redeems.mdx
@@ -2,7 +2,7 @@
 title: Redeems
 description: Introduction to redeems
 ---
-import {CardGrid} from "@astrojs/starlight/components";
+import {Aside, CardGrid} from "@astrojs/starlight/components";
 import RedeemCard from '../components/RedeemCard.astro';
 import {redeems} from "../redeems.ts";
 
@@ -99,6 +99,18 @@ By using this redeem, your link will be verified by our moderators.
 
 When all is well, your link will be shared in chat,
 so we can all watch charming cat girls - I mean, look at the very serious documentation.
+
+### Just Unit Test
+
+Jane promises she will write a
+[unit test](https://en.wikipedia.org/wiki/Unit_testing).
+She will actually sit through the process of writing a unit test for her code.
+You asked for it!
+
+<Aside type="caution">
+    It is up to Jane whether writing a unit test would disrupt the stream.
+    She may refund your channel points, rather than writing the unit test.
+</Aside>
 
 ## Off the clock
 
@@ -234,6 +246,11 @@ Jane says the thing.
 Jane will turn _your_ text to speech.
 No thoughts, head empty.
 Jane will be your TTS and speak what you wrote in the redeem message.
+
+### Just Stay Positive
+
+Jane will take a moment to tell herself how strong, independent, capable, and
+worthy of good things in her life she is.
 
 ## Interact with Jill
 

--- a/src/content/docs/redeems.mdx
+++ b/src/content/docs/redeems.mdx
@@ -13,7 +13,9 @@ Chat redeems can be paid by using
 [channel points](https://help.twitch.tv/s/article/channel-points-faq#viewer).
 Here is an overview of all the redeems and their cost in channel points.
 
-<CardGrid>{redeems.map((redeem) => <RedeemCard {...redeem} />)}</CardGrid>
+<CardGrid stagger={redeems.length % 2 === 1}>{redeems.map(
+    (redeem) => <RedeemCard {...redeem} />
+)}</CardGrid>
 
 ## On the clock
 

--- a/src/content/docs/redeems.mdx
+++ b/src/content/docs/redeems.mdx
@@ -105,6 +105,10 @@ so we can all watch charming cat girls - I mean, look at the very serious docume
 A well rested and entertained employee is a productive employee.
 Jane has stimmies for a wide variety of downtime.
 
+### Test Rod LVL 1
+
+Redeem this rod to help test the [fishing game](/bahms/fishing).
+
 ### Just Zshoom
 
 Allows you to control a ship in the [bounce house](/bahms/bounce-house/#ships)...

--- a/src/content/docs/redeems.mdx
+++ b/src/content/docs/redeems.mdx
@@ -252,7 +252,7 @@ Jane will be your TTS and speak what you wrote in the redeem message.
 ### Just Stay Positive
 
 Jane will take a moment to tell herself how strong, independent, capable, and
-worthy of good things in her life she is.
+amazing she is.
 
 ## Interact with Jill
 
@@ -279,4 +279,4 @@ One of the moderators will get in touch with you after redeeming a custom voice,
 to give you specific instructions on how to record your voice.
 
 You will then have the ability to use it, exclusively, for at least 20 streams.
-After 20 streams your TTS voice may reset to room for someone else to have their voice customized.
+After 20 streams your TTS voice may reset to make room for someone else to have their voice customized.

--- a/src/content/redeems.ts
+++ b/src/content/redeems.ts
@@ -139,6 +139,13 @@ export const redeems: RedeemProps[] = [
         channelPoints: '1,024'
     },
     {
+        title: 'Just Stay Positive',
+        anchor: '#just-stay-positive',
+        iconBackgroundColor: 'rgb(192, 202, 245)',
+        iconUrl: defaultIcon,
+        channelPoints: '2,048'
+    },
+    {
         title: 'Just Bark',
         anchor: '#just-bark',
         iconBackgroundColor: 'rgb(192, 202, 245)',
@@ -165,5 +172,12 @@ export const redeems: RedeemProps[] = [
         iconBackgroundColor: 'rgb(128, 218, 215)',
         iconUrl: redeemIcon('e5c0380c-2afd-4796-8296-d7212b2f2144/4bd25155-737e-4abc-8c96-a4fbc8861b4d'),
         channelPoints: '32,768'
+    },
+    {
+        title: 'Just Unit Test',
+        anchor: '#just-unit-test',
+        iconBackgroundColor: 'rgb(192, 202, 245)',
+        iconUrl: redeemIcon('fa193225-0f67-403a-974a-1eac1a2d4d96/e5c98bdd-c628-4d4c-b1b8-f6f1e653b170'),
+        channelPoints: '131,072'
     },
 ]

--- a/src/content/redeems.ts
+++ b/src/content/redeems.ts
@@ -6,7 +6,7 @@ type RedeemProps = ComponentProps<typeof RedeemCard>;
 // Helpers to make manually configured icon URLs easier to read.
 const broadcasterId = '1112386096';
 const iconBaseUrl = 'https://static-cdn.jtvnw.net/custom-reward-images'
-// const defaultIcon = new URL(`${iconBaseUrl}/default-2.png`)
+const defaultIcon = new URL(`${iconBaseUrl}/default-2.png`)
 const icons: Record<'1x'|'2x', string> = {
     '1x': 'custom-2.png',
     '2x': 'custom-4.png'
@@ -19,6 +19,13 @@ const redeemIcon = (
 
 // @todo Let this list be populated by the Twitch API.
 export const redeems: RedeemProps[] = [
+    {
+        title: 'Test Rod LVL 1',
+        anchor: '#test-rod-lvl-1',
+        iconBackgroundColor: 'rgb(189, 0, 120)',
+        iconUrl: defaultIcon,
+        channelPoints: 1
+    },
     {
         title: 'Just Pyramid Scheme',
         anchor: '#just-pyramid-scheme',


### PR DESCRIPTION
closes #33 
closes #35 

- Add links to the API documentation
- Add links to the fishing game documentation
- Restore redeems
  - Just Unit Test
  - Just Stay Positive
- Add "Test Rod LVL 1" redeem
- Made cardgrid for redeems staggered when the number of redeems is uneven
- Add "Fishing" section to commands
- Add basic documentation on the fishing game


https://github.com/user-attachments/assets/346013f0-2f2f-41ca-afe2-08fd94f65ca2