### PR TITLE
Reset fish icon `max-width`

### DIFF
--- a/src/content/components/FishSpeciesOverview.astro
+++ b/src/content/components/FishSpeciesOverview.astro
@@ -106,6 +106,11 @@
         margin-block-start: 1em;
         margin-block-end: 2em;
 
+        img {
+            /* Resets starlight styling */
+            max-width: none;
+        }
+
         meter {
             --background: color(from var(--sl-color-bg-accent) srgb r g b / 0.1);
             --optimum: var(--sl-color-accent-high);


### PR DESCRIPTION
The Starlight theme would have the `max-width` of images at `100%`, which would make the icons for fish shrink into nothing on smaller viewports, like mobile browsers.

closes #37 

<img width="735" height="675" alt="image" src="https://github.com/user-attachments/assets/fc400cf8-dc84-41b2-affe-06884e9c6ad1" />
